### PR TITLE
Centered single images and photosets in images posts

### DIFF
--- a/Ashley.html
+++ b/Ashley.html
@@ -374,7 +374,7 @@
 
 						{block:Photo}
 							{LinkOpenTag}
-                <img src="{PhotoURL-HighRes}" alt="{PhotoAlt}">           
+                <img src="{PhotoURL-HighRes}" alt="{PhotoAlt}" class="singlePhoto">           
 							{LinkCloseTag}
 
 							{block:Caption}

--- a/Ashley.html
+++ b/Ashley.html
@@ -162,7 +162,7 @@
         max-width: 100%;
       }
       
-      .post iframe, .video object {
+      .post iframe:not(.photoset), .video object {
         width: 100%;
         max-width: 100%;
       }
@@ -323,6 +323,16 @@
       .notes blockquote {
         line-height: 1.5;
         margin-left: 3em;
+      }
+      
+      img.singlePhoto {
+        display:block;
+        margin: auto
+      }
+
+      iframe.photoset {
+        margin: auto;
+        display: table;
       }
 		  
 			{CustomCSS}


### PR DESCRIPTION
Photos smaller than the maximum width & Photoset iframes have been centered, made sure not to effect other iframes when centering the the photosets.

And I've tested on all current browsers.
