### PR TITLE
Made photosets responsive

### DIFF
--- a/Ashley.html
+++ b/Ashley.html
@@ -355,7 +355,7 @@
 						{/block:Photo}
 
 						{block:Photoset}
-							{Photoset-500}
+							{Photoset}
 
 							{block:Caption}
 								{Caption}
@@ -478,6 +478,17 @@
 		{block:AskEnabled}<a href="/ask">{AskLabel}</a>{/block:AskEnabled}
 	  {block:IfColophon}<p class="small">{text:Colophon}</p>{block:IfColophon}
 	</footer>
-	
+	<script>
+    function resizePhotosets(){
+      var parentWidth = document.body.querySelector('.html_photoset').offsetWidth; 
+      var photosets = document.body.querySelectorAll('iframe.photoset');
+      for(var i = 0; i < photosets.length; ++i){
+        var photoset = photosets[i];
+        photoset.width = parentWidth;
+      }   
+    }
+    window.onload = resizePhotosets;
+    window.onresize = resizePhotosets;
+  </script>
 </body>
 </html>


### PR DESCRIPTION
I've used the Tumblr-provided but mysteriously undocumented {Photoset} tag to render photosets at 100% of parent width, and a few lines of JavaScript to make mobile browsers pay attention...

For reasons unbeknownst to me, Safari & Chrome (on iOS 6 & 7) would otherwise display the photoset iframe at it's maximum possible width, and not 100% of the viewport's.

The JS I wrote to do this is probably not flawless, but I figured it was better than including 30kb+ library to do it. 

Tested, working in iOS 7 Chrome & Safari. Test Tumblelog: http://ea-photosets-ashley.tumblr.com
