### PR TITLE
Support for Disqus added

### DIFF
--- a/Ashley.html
+++ b/Ashley.html
@@ -15,6 +15,7 @@
 		<meta name="text:Colophon" content="Ashley theme by Jxnblk"/>
 		<meta name="text:GoogleWebFont" content="Gentium Book Basic"/>
 		<meta name="text:GoogleWebFontURL" content="Gentium+Book+Basic"/>
+		<meta name="text:Disqus Shortname" content="<Your Disqus ShortName>"/>
 		<meta name="color:Background" content="#fff"/>
     <meta name="color:Text" content="#444"/>
     <meta name="color:Link" content="#09b"/>
@@ -455,6 +456,26 @@
   				{/block:PostNotes}
 
 				{/block:Posts}
+				<!-- Start Disqus -->
+				{block:IfDisqusShortname}
+
+					<div id="disqus_thread"></div>
+					<script type="text/javascript">
+					    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+					    var disqus_shortname = '{text:Disqus Shortname}'; // Required - Replace <example> with your forum shortname
+
+					    /* * * DON'T EDIT BELOW THIS LINE * * */
+					    (function() {
+					        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+					        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+					        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+					    })();
+					</script>
+					<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+					<a href="http://disqus.com" class="dsq-brlink">blog comments powered by <span class="logo-disqus">Disqus</span></a>
+
+				{/block:IfDisqusShortname}
+				<!-- End Disqus -->
 				
 				{block:Pagination}
 					<div class="pagination p">

--- a/Ashley.html
+++ b/Ashley.html
@@ -454,7 +454,20 @@
     					{PostNotes-64}
   				  </aside>
   				{/block:PostNotes}
+				
+				{block:IndexPage}<a class="dsq-comment-count" href="{Permalink}#disqus_thread">Comments</a>
+				<script type="text/javascript">
+				    var disqus_shortname = '{text:Disqus Shortname}';
 
+				    (function () {
+				        var s = document.createElement('script'); s.async = true;
+				        s.type = 'text/javascript';
+				        s.src = '//' + disqus_shortname + '.disqus.com/count.js';
+				        (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
+				    }());
+				</script>
+				{/block:IndexPage}
+				
 				{/block:Posts}
 				<!-- Start Disqus -->
 				{block:IfDisqusShortname}

--- a/Ashley.html
+++ b/Ashley.html
@@ -15,7 +15,7 @@
 		<meta name="text:Colophon" content="Ashley theme by Jxnblk"/>
 		<meta name="text:GoogleWebFont" content="Gentium Book Basic"/>
 		<meta name="text:GoogleWebFontURL" content="Gentium+Book+Basic"/>
-		<meta name="text:Disqus Shortname" content="<Your Disqus ShortName>"/>
+		<meta name="text:Disqus Shortname" content=""/>
 		<meta name="color:Background" content="#fff"/>
     <meta name="color:Text" content="#444"/>
     <meta name="color:Link" content="#09b"/>


### PR DESCRIPTION
Added the Disqus code snippet for Disqus comments for the theme. 
A textbox to enter the Disqus short name also shows up where the user can enter his shortname and voila, Disqus comments on their blog. 

If the field is left empty, then Disqus comments won't show up. 
![screen shot 2014-06-14 at 7 51 41 pm](https://cloud.githubusercontent.com/assets/915425/3278729/99ffa05e-f3cf-11e3-9581-73b94a83a76d.png)
