### PR TITLE
Fixed pagination

### DIFF
--- a/Ashley.html
+++ b/Ashley.html
@@ -458,9 +458,9 @@
 				
 				{block:Pagination}
 					<div class="pagination p">
-						<span class="previous">{block:PreviousPage}<a href="{PreviousPage}" class="previous">{/block:PreviousPage}&laquo; Previous{block:PreviousPage}</a>{/block:PreviousPage}</span>
+						<span class="previous">{block:PreviousPage}<a href="{PreviousPage}" class="previous">{/block:PreviousPage}&laquo; Next{block:PreviousPage}</a>{/block:PreviousPage}</span>
 						<span class="page-numbers">{CurrentPage}/{TotalPages}</span>
-						<span class="next">{block:NextPage}<a href="{NextPage}">{/block:NextPage}Next &raquo;{block:NextPage}</a>{/block:NextPage}</span>
+						<span class="next">{block:NextPage}<a href="{NextPage}">{/block:NextPage}Previous &raquo;{block:NextPage}</a>{/block:NextPage}</span>
 					</div>
 				{/block:Pagination}
 							


### PR DESCRIPTION
Flipped "previous" with "next."

There seems to be a temporal paradox... 

"Next" currently takes you backwards in time, while "Previous" takes you forwards in time.
